### PR TITLE
Workaround no ON_POSIX in xonsh.tools on Windows

### DIFF
--- a/xonsh_kernel/kernel.py
+++ b/xonsh_kernel/kernel.py
@@ -7,7 +7,12 @@ from tempfile import SpooledTemporaryFile
 
 from metakernel import MetaKernel
 from xonsh import __version__ as version
-from xonsh.tools import redirect_stdout, redirect_stderr, swap, ON_POSIX
+from xonsh.tools import redirect_stdout, redirect_stderr, swap
+try:
+    from xonsh.tools import ON_POSIX
+except ImportError:
+    ON_POSIX=None
+    pass
 
 from . import __version__
 


### PR DESCRIPTION
Simple fix for Issue #6 

As ON_POSIX symbol is not available in xonsh.tools on Windows, we catch the ImportError and set ON_POSIX to None.
